### PR TITLE
Better support for Android

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,11 @@ gemspec
 
 ruby '2.0.0', engine: 'jruby', engine_version: '1.7.15'
 
-gem 'xml-write-stream', '~> 1.0.0', path: '~/workspace/xml-write-stream'
+gem 'xml-write-stream', '~> 1.1.0', path: '~/workspace/xml-write-stream'
 
 gem 'rosette-core', '~> 1.0.0', path: '~/workspace/rosette-core'
 gem 'rosette-extractor-xml', '~> 1.0.0', path: '~/workspace/rosette-extractor-xml'
 gem 'jbundler'
-gem 'builder', '~> 3.2.0'
 
 group :development, :test do
   gem 'pry', '~> 0.9.0'

--- a/lib/ext/htmlentities/android_xml.rb
+++ b/lib/ext/htmlentities/android_xml.rb
@@ -1,0 +1,23 @@
+require 'htmlentities'
+
+class HTMLEntities
+  MAPPINGS['android_xml'] = MAPPINGS['xhtml1'].dup.tap do |mappings|
+    mappings['apos'] = "'"
+  end
+
+  FLAVORS << 'android_xml'
+
+  class AndroidXmlEncoder < Encoder
+    def initialize(instructions = [])
+      super('android_xml', instructions)
+    end
+
+    private
+
+    # had to adjust this so that single and double quotes don't get turned into
+    # entities (they're escaped by hand with backslashes)
+    def basic_entity_regexp
+      @basic_entity_regexp ||= /[<>&]/
+    end
+  end
+end

--- a/lib/ext/htmlentities/android_xml.rb
+++ b/lib/ext/htmlentities/android_xml.rb
@@ -2,7 +2,7 @@ require 'htmlentities'
 
 class HTMLEntities
   MAPPINGS['android_xml'] = MAPPINGS['xhtml1'].dup.tap do |mappings|
-    mappings['apos'] = "'"
+    mappings.delete('apos')
   end
 
   FLAVORS << 'android_xml'

--- a/rosette-serializer-xml.gemspec
+++ b/rosette-serializer-xml.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.has_rdoc = true
 
+  s.add_dependency 'htmlentities', '~> 4.3'
+
   s.require_path = 'lib'
   s.files = Dir["{lib,spec}/**/*", "Gemfile", "History.txt", "README.md", "Rakefile", "rosette-serializer-xml.gemspec"]
 end

--- a/rosette-serializer-xml.gemspec
+++ b/rosette-serializer-xml.gemspec
@@ -2,20 +2,20 @@ $:.unshift File.join(File.dirname(__FILE__), 'lib')
 require 'rosette/serializers/xml/version'
 
 Gem::Specification.new do |s|
-  s.name     = "rosette-serializer-xml"
+  s.name     = 'rosette-serializer-xml'
   s.version  = ::Rosette::XmlSerializerVersion::VERSION
-  s.authors  = ["Cameron Dutro"]
-  s.email    = ["camertron@gmail.com"]
-  s.homepage = "http://github.com/camertron"
+  s.authors  = ['Cameron Dutro']
+  s.email    = ['camertron@gmail.com']
+  s.homepage = 'http://github.com/camertron'
 
-  s.description = s.summary = "A streaming XML serializer for the Rosette internationalization platform."
+  s.description = s.summary = 'A streaming XML serializer for the Rosette internationalization platform.'
 
   s.platform = Gem::Platform::RUBY
   s.has_rdoc = true
 
   s.add_dependency 'htmlentities', '~> 4.3'
-  s.add_dependency 'xml-write-stream', '~> 1.0.0'
+  s.add_dependency 'xml-write-stream', '~> 1.0'
 
   s.require_path = 'lib'
-  s.files = Dir["{lib,spec}/**/*", "Gemfile", "History.txt", "README.md", "Rakefile", "rosette-serializer-xml.gemspec"]
+  s.files = Dir["{lib,spec}/**/*", 'Gemfile', 'History.txt', 'README.md', 'Rakefile', 'rosette-serializer-xml.gemspec']
 end

--- a/spec/android-serializer_spec.rb
+++ b/spec/android-serializer_spec.rb
@@ -32,12 +32,10 @@ describe XmlSerializer::AndroidSerializer do
       |
         <?xml version="1.0" encoding="UTF-8"?>
         <resources>
-            <string name="foo">
-                "bar"
-            </string>
+            <string name="foo">bar</string>
         </resources>
       EOM
-    ))
+    ).strip)
   end
 
   it 'detects and writes plurals' do
@@ -51,16 +49,12 @@ describe XmlSerializer::AndroidSerializer do
         <?xml version="1.0" encoding="UTF-8"?>
         <resources>
             <plurals name="horses">
-                <item quantity="one">
-                    "There is one horse"
-                </item>
-                <item quantity="other">
-                    "There are %d horses"
-                </item>
+                <item quantity="one">There is one horse</item>
+                <item quantity="other">There are %d horses</item>
             </plurals>
         </resources>
       EOM
-    ))
+    ).strip)
   end
 
   it 'detects and writes arrays in any order' do
@@ -76,22 +70,14 @@ describe XmlSerializer::AndroidSerializer do
         <?xml version="1.0" encoding="UTF-8"?>
         <resources>
             <string-array name="captains">
-                <item>
-                    "Janeway"
-                </item>
-                <item>
-                    "Kirk"
-                </item>
-                <item>
-                    "Picard"
-                </item>
-                <item>
-                    "Sisko"
-                </item>
+                <item>Janeway</item>
+                <item>Kirk</item>
+                <item>Picard</item>
+                <item>Sisko</item>
             </string-array>
         </resources>
       EOM
-    ))
+    ).strip)
   end
 
   it "doesn't escape entities" do
@@ -103,12 +89,10 @@ describe XmlSerializer::AndroidSerializer do
       |
         <?xml version="1.0" encoding="UTF-8"?>
         <resources>
-            <string name="states">
-                "Alaska & Hawai'i"
-            </string>
+            <string name="states">Alaska &amp; Hawai\\'i</string>
         </resources>
       EOM
-    ))
+    ).strip)
   end
 
   it 'escapes double quotes' do
@@ -120,12 +104,10 @@ describe XmlSerializer::AndroidSerializer do
       |
         <?xml version="1.0" encoding="UTF-8"?>
         <resources>
-            <string name="wow">
-                "And I said \\"cool\\""
-            </string>
+            <string name="wow">And I said \\"cool\\"</string>
         </resources>
       EOM
-    ))
+    ).strip)
   end
 
   it 'writes a mixture of all types of string' do
@@ -141,27 +123,17 @@ describe XmlSerializer::AndroidSerializer do
       |
         <?xml version="1.0" encoding="UTF-8"?>
         <resources>
-            <string name="justastring">
-                "I'm very basic"
-            </string>
+            <string name="justastring">I\\'m very basic</string>
             <plurals name="justaplural">
-                <item quantity="many">
-                    "Many plurals"
-                </item>
-                <item quantity="one">
-                    "One plural"
-                </item>
+                <item quantity="many">Many plurals</item>
+                <item quantity="one">One plural</item>
             </plurals>
             <string-array name="justanarray">
-                <item>
-                    "First in line"
-                </item>
-                <item>
-                    "Second in line"
-                </item>
+                <item>First in line</item>
+                <item>Second in line</item>
             </string-array>
         </resources>
       EOM
-    ))
+    ).strip)
   end
 end


### PR DESCRIPTION
This PR tries to make Android XML formatting a little nicer (mostly so our diffs don't look crazy). Namely these are the changes:
1. `<string>` tags (as well as array elements and plural items) and their content are now written on a single line.
2. Instead of surrounding content with double quotes, the serializer now escapes single and double quotes.
3. With the exception of single quotes, all HTML-unsafe entities are now replaced with their HTML-safe equivalents. Specifically, this means `&` becomes `&amp;`, but `'` does _not_ become `&apos;`.

@jdoconnor @seunghyo @zvkemp @11mdlow
